### PR TITLE
Fix converter and use model deeplabv3_mnv2_pascal_quant_edgetpu.tflile for light/TPU

### DIFF
--- a/tf1totf2lite.py
+++ b/tf1totf2lite.py
@@ -78,14 +78,14 @@ def convert(input, output, quantization):
         converter.optimizations = [tf.lite.Optimize.DEFAULT]
         converter.target_spec.supported_types = [tf.float16]
 
-    elif quantization in ('i8', 'int8', 'Fi8', 'full_int8'):
+    elif quantization in ('ui8', 'uint8', 'Fui8', 'full_uint8'):
         converter.optimizations = [tf.lite.Optimize.DEFAULT]
         converter.representative_dataset = representative_dataset_gen
 
-        if quantization in ('Fi8', 'full_int8'):
+        if quantization in ('Fui8', 'full_uint8'):
             converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
-            converter.inference_input_type = tf.int8  # or tf.uint8
-            converter.inference_output_type = tf.int8  # or tf.uint8
+            converter.inference_input_type = tf.uint8  # or tf.uint8
+            converter.inference_output_type = tf.uint8  # or tf.uint8
 
     tflite_model = converter.convert()
     open(output, 'wb').write(tflite_model)
@@ -93,11 +93,15 @@ def convert(input, output, quantization):
 
 def main(args):
     parser = argparse.ArgumentParser(
-        description=f'''onvert TF1 model to TF2 Lite.
-Example: {sys.argv[0]} frozen_inference_graph.pb xception_coco_voctrainval.tflite
+        description=f'''Convert TF1 model to TF2 Lite.
+Example:
+
+{sys.argv[0]} frozen_inference_graph.pb xception_coco_voctrainval.tflite
+
+{sys.argv[0]} -q full_uint8 frozen_inference_graph.pb xception_coco_voctrainval-full_uint8.tflite
 ''')
     parser.add_argument('-q', '--quantization',
-        choices=['dr', 'dynamic_range', 'i8', 'int8', 'Fi8', 'full_int8', 'f16', 'float16'],
+        choices=['dr', 'dynamic_range', 'ui8', 'uint8', 'Fui8', 'full_uint8', 'f16', 'float16'],
         help='''Optimization Quantization
  - dr, dynamic_range: 4x smaller, 2x-3x speedup - CPU (mono-thread)
  - f16, float16: 2x smaller, GPU acceleration - CPU, GPU


### PR DESCRIPTION
Make it works with TPU hardware.

I convert the xception_coco_voctrainval model to tflite format. But I was not able to convert to edgetpu.tflile. It requires more memory than I have (24GB), and so I think it would be bigger than the acceptable size of the TPU memory.

I use a very similar model already available on edgetpu.tflile format: deeplabv3_mnv2_pascal_quant_edgetpu.tflite

Result with dezoom 1 in 3min35, on 1 CPU.
![imagen](https://user-images.githubusercontent.com/1785486/90808568-84852b80-e320-11ea-828a-f27873976c2f.png)

Result with dezoom 1 in 5.5s, on 1 TPU.
![imagen](https://user-images.githubusercontent.com/1785486/90808617-99fa5580-e320-11ea-929f-cd544da4e077.png)

As I understand the difference on the models is small, but on runtime is using float on CPU and the integer on TPU. The second is more sensible the sub picture boundary.

cc @cquest