### PR TITLE
Fix versioning test, and uninitialised variables on first iteration 

### DIFF
--- a/blur_persons.py
+++ b/blur_persons.py
@@ -255,6 +255,7 @@ def iter_image_sub_boxes(image_width, image_height, box_size, is_360=None, overl
             yield result
 
 def blur_from_model_and_colormap(original_image, model, colormap, blur, dezoom=1.0, mask=False):
+    x2_1 = None
     width, height = original_image.size
     is_360 = (width == (2 * height))
     if type(blur) is int:
@@ -291,6 +292,12 @@ def blur_from_model_and_colormap(original_image, model, colormap, blur, dezoom=1
         resized_im, segmentation_map = model.run(resized_image)
         segmentation_mask = Image.fromarray(np.uint8(colormap[segmentation_map])).resize((x2-x1, y2-y1), Image.NEAREST if mask else Image.ANTIALIAS)
         if x2 >= width and is_360:
+            if x2_1 is None:
+                x2_1 = width
+                x2_2 = x2 - width
+                extract_width_1 = x2_1 - x1
+                extract_width_2 = x2_2
+
             new_image.paste(blurred_im.crop((x1,y1, x2_1,y2)), (x1,y1), segmentation_mask.crop((0,0, extract_width_1, extract_height)))
             new_image.paste(blurred_im.crop((0,y1, x2_2,y2)), (0,y1), segmentation_mask.crop((extract_width_1,0, extract_width, extract_height)))
         else:

--- a/blur_persons.py
+++ b/blur_persons.py
@@ -24,8 +24,10 @@ import numpy as np
 
 from PIL import Image, ImageDraw, ImageFilter, ImageColor
 
+from packaging import version 
+
 import tensorflow.compat.v1 as tf
-if tf.__version__ < '1.5.0':
+if version.parse(tf.__version__) < version.parse('1.5'):
     raise ImportError('Please upgrade your tensorflow installation to v1.5.0 or newer!')
 
 


### PR DESCRIPTION
On my systems (Ubuntu 18.04 running Python 3.6, not Anaconda, just a standard Linux Python distribution), I found that the code as it stands would not work.
The Tensorflow version test failed, I have Tensorflow 1.15 but it reported it as older than version 1.5; it appears to be using simple string comparisons. So, version parsing from the 'packaging' package has been added.

Also, for 360 panos, the blur_from_model_and_colormap() failed. This appears to be because the variables x2_1, x2_2, extract_width_1 and extract_width_2 are uninitialised. Initally the first `if x2 >= width and is_360` test returns False, because it's testing the entire image, not an extract. However, the first rectangle is then extracted and the second  `if x2 >= width and is_360` test then returns True, because `width` has changed. Consequently the code inside the `if` block runs, and an error is encountered as the four variables are uninitialised, because the first `if` returned false.

The PR works by initialising `x2_1` to `None` initially, and then testing if `x2_1` is `None` in the second `if` statement as above. If it's `None`, the four missing variables are appropriately initialised.